### PR TITLE
Remove use of reserved keyword arguments as an argument name

### DIFF
--- a/lib/vargs.js
+++ b/lib/vargs.js
@@ -21,7 +21,7 @@
 //       args.array           // all arguments, including callback
 //   }
 //
-exports.Constructor = function Vargs(arguments) {
+exports.Constructor = function Vargs() {
     this.array = Array.prototype.slice.call(arguments);
     this.__defineGetter__('length', function () {
         if (this.callbackGiven()) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vargs",
+  "version": "0.1.1",
+  "description": "variable argument handling for functions taking a callback",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudhead/vargs"
+  },
+  "author": "Alexis Sellier",
+  "bugs": {
+    "url": "https://github.com/cloudhead/vargs/issues"
+  },
+  "homepage": "https://github.com/cloudhead/vargs"
+}


### PR DESCRIPTION
This argument is obscured by the arguments object anyway.  It is the only strict mode violation in the module.  Making this one line change allows the module to load in strict mode while making no change to the functionality.  

I also created a package.json as best I could with appropriate values pulled from the repo's `README.md` so I could bump the version number 
